### PR TITLE
Change EINTR handling to match EAGAIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ read nbytes of data from the specified position in the file without modifying th
 
 - `s:string`: read data from the file or `nil`. if a `nbytes` is `0` then return an `nil`.
 - `err:any`: error object if an error occurs.
-- `again:boolean`: `true` if it cannot read data because of end of file, or `pread` sets the `errno` to `EAGAIN` or `EWOULDBLOCK`. 
+- `again:boolean`: `true` if it cannot read data because of end of file, or `pread` sets the `errno` to `EAGAIN`, `EWOULDBLOCK` or `EINTR`.
 
 **Example**
 

--- a/src/pread.c
+++ b/src/pread.c
@@ -65,7 +65,6 @@ static int pcall_pread_lua(lua_State *L)
     }
 #endif
 
-RETRY:
     n = pread(fd, buf, nbyte, offset);
     if (n > 0) {
 #if LUA_VERSION_NUM > 501
@@ -81,16 +80,13 @@ RETRY:
         return 1;
     }
 
-    if (n == 0 || errno == EAGAIN || errno == EWOULDBLOCK) {
+    if (n == 0 || errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
         // reached to EOF or try again
         lua_settop(L, 0);
         lua_pushnil(L);
         lua_pushnil(L);
         lua_pushboolean(L, 1);
         return 3;
-    } else if (errno == EINTR) {
-        // retry if interrupted by signal
-        goto RETRY;
     }
 
     // error occurred


### PR DESCRIPTION
This pull request updates the handling of the `EINTR` error in the `pread` function implementation and its documentation. The changes ensure that the `EINTR` error is treated consistently with other retryable errors and simplify the code by removing the retry logic.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R37): Updated the description of the `again` return value to include `EINTR` as a condition for retrying the `pread` operation.

### Code Simplification:
* [`src/pread.c`](diffhunk://#diff-5814155b9a6783b72ba10d6d3b34da5c556e8d314858bdffc5443a3ff831e47aL68): Removed the `RETRY` label and the retry logic for handling `EINTR`, instead treating it like other retryable errors (`EAGAIN`, `EWOULDBLOCK`) by returning a boolean indicating the need to retry. [[1]](diffhunk://#diff-5814155b9a6783b72ba10d6d3b34da5c556e8d314858bdffc5443a3ff831e47aL68) [[2]](diffhunk://#diff-5814155b9a6783b72ba10d6d3b34da5c556e8d314858bdffc5443a3ff831e47aL84-L93)